### PR TITLE
Fix little typos

### DIFF
--- a/colorist-doc-en.tex
+++ b/colorist-doc-en.tex
@@ -175,7 +175,7 @@ For example, after using \lstinline|\UseLanguage{French}|, the theorem and the d
 
 \UseLanguage{French}
 \begin{theorem}[Inutile]\label{thm}
-    Un théorem en Français. \dnf
+    Un théorème en français. \dnf
 \end{theorem}
 
 When referenced, the name of the theorem always matches the language of the region in which the theorem is located, for example, the definition of the beginning is still displayed in English in the current French mode: \cref{def: strange} and \cref{thm}。


### PR DESCRIPTION
The French word for "theorem" is "théorème". In French, the language is spelled "français", without a capital letter (the inhabitants are still spelled "Français" with a capital letter).